### PR TITLE
attachments: implemented ListAllAttachmentsForTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,22 @@ func main() {
 	fmt.Printf("Response attachment: %#v\n", respAttachment)
 }
 ```
+
+## List all attachments for a task
+```go
+func main() {
+	client, err := asana.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	attachmentsPage, err := client.ListAllAttachmentsForTask("331727965981099")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, task := range attachmentsPage.Attachments {
+		fmt.Printf("Task #%d: %#v\n\n", i, task)
+	}
+}
+```

--- a/v1/attachment.go
+++ b/v1/attachment.go
@@ -154,6 +154,34 @@ func (c *Client) UploadAttachment(au *AttachmentUpload) (*Attachment, error) {
 	return parseOutAttachmentFromData(slurp)
 }
 
+type AttachmentsPage struct {
+	Attachments []*Attachment `json:"data"`
+}
+
+// ListAllAttachmentsForTask retrieves all the attachments for the taskID provided.
+func (c *Client) ListAllAttachmentsForTask(taskID string) (*AttachmentsPage, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil, errEmptyTaskID
+	}
+	fullURL := fmt.Sprintf("%s/tasks/%s/attachments", baseURL, taskID)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	slurp, _, err := c.doAuthReqThenSlurpBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	apage := new(AttachmentsPage)
+	if err := json.Unmarshal(slurp, apage); err != nil {
+		return nil, err
+	}
+	return apage, nil
+}
+
 func writeStringField(w *multipart.Writer, key, value string) {
 	fw, err := w.CreateFormField(key)
 	if err == nil {

--- a/v1/example_test.go
+++ b/v1/example_test.go
@@ -460,3 +460,19 @@ func Example_client_UploadAttachment() {
 	}
 	fmt.Printf("Response attachment: %#v\n", respAttachment)
 }
+
+func Example_client_ListAllAttachmentsForTask() {
+	client, err := asana.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	attachmentsPage, err := client.ListAllAttachmentsForTask("331727965981099")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, task := range attachmentsPage.Attachments {
+		fmt.Printf("Task #%d: %#v\n\n", i, task)
+	}
+}

--- a/v1/task.go
+++ b/v1/task.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -403,7 +402,6 @@ func (c *Client) doTasksPaging(path string) (resultsChan chan *TaskResultPage, c
 
 		for {
 			fullURL := fmt.Sprintf("%s%s", baseURL, path)
-			log.Printf("fullURL: %q", fullURL)
 			req, err := http.NewRequest("GET", fullURL, nil)
 			if err != nil {
 				tasksPageChan <- &TaskResultPage{Err: err}
@@ -411,7 +409,6 @@ func (c *Client) doTasksPaging(path string) (resultsChan chan *TaskResultPage, c
 			}
 
 			slurp, _, err := c.doAuthReqThenSlurpBody(req)
-log.Printf("slurp: %s\n", slurp)
 			if err != nil {
 				tasksPageChan <- &TaskResultPage{Err: err}
 				return

--- a/v1/teams.go
+++ b/v1/teams.go
@@ -111,7 +111,6 @@ func (c *Client) RemoveUserFromTeam(treq *TeamRequest) error {
 	return err
 }
 
-
 type teamWrap struct {
 	Team *Team `json:"data"`
 }

--- a/v1/testdata/task-attachments-task-id-1.json
+++ b/v1/testdata/task-attachments-task-id-1.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "id": 5678,
+      "name": "Background.png"
+    },
+    {
+      "id": 9012,
+      "name": "New Design Draft.pdf"
+    }
+  ]
+}


### PR DESCRIPTION
Completes #7.

A method to list all the attachments for a task.

Sample usage:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/asana/v1"
)

func main() {
	client, err := asana.NewClient()
	if err != nil {
		log.Fatal(err)
	}

	attachmentsPage, err := client.ListAllAttachmentsForTask("331727965981099")
	if err != nil {
		log.Fatal(err)
	}

	for i, task := range attachmentsPage.Attachments {
		fmt.Printf("Task #%d: %#v\n\n", i, task)
	}
}
```